### PR TITLE
Fix potgresql keywords in table names

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -131,7 +131,9 @@ class PgAnonymizer extends Command {
 
     for await (let line of inputLineResults) {
       if (line.match(/^COPY .* FROM stdin;$/)) {
-        table = line.replace(/^COPY (.*?) .*$/, "$1");
+        table = line
+          .replace(/^COPY (.*?) .*$/, "$1")
+          .replace(/"/g, "");
         console.error("Anonymizing table " + table);
 
         cols = line


### PR DESCRIPTION
Fix potgresql keywords in table names not matching to obfuscation argument names.
To fix that I added "replace" that removes any quotes from the comparison mechanism so that the obfuscation methods are properly matched. The output of this script is still valid and contains required quotes.